### PR TITLE
Excluded supportingsolutionid column from query which is causing read error

### DIFF
--- a/AccessTeamMoverPlugin/Utility/FetchXmlHelper.cs
+++ b/AccessTeamMoverPlugin/Utility/FetchXmlHelper.cs
@@ -11,7 +11,7 @@ namespace DynamicsCode.AccessTeamTemplateMoverPlugin.Utility
 
         public FetchXmlHelper()
         {
-            ignoredAttributes = new string[] { "issystem" };
+            ignoredAttributes = new string[] { "issystem", "supportingsolutionid" };
         }
 
         public string Build(string entityName, AttributeMetadata[] attributeMetadata)


### PR DESCRIPTION
A supportingsolutionid attribute in the teamtemplate entity is causing the following error when the user **Export and Save** the team template.

![image](https://github.com/dynamicscode/AccessTeamTemplateMover/assets/14156926/51b1e71d-8679-4b7c-b894-21e066b77635)
